### PR TITLE
Fix factory to use already created users, countries or provinces

### DIFF
--- a/laravel/database/factories/MunicipalParkingSpotFactory.php
+++ b/laravel/database/factories/MunicipalParkingSpotFactory.php
@@ -21,8 +21,17 @@ class MunicipalParkingSpotFactory extends Factory
     {
         return [
             'id' => fake()->unique()->bothify('##??##'),
-            'country_id' => Country::factory(),
-            'province_id' => Province::factory(),
+            'country_id' => function (): mixed {
+                return Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+            },
+            'province_id' => function (): mixed {
+                $countryId = Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+
+                return Province::where('country_id', $countryId)
+                    ->inRandomOrder()
+                    ->value('id')
+                    ?? Province::factory()->create(['country_id' => $countryId])->id;
+            },
             'municipality' => fake()->city,
             'street' => fake()->streetName,
             'orientation' => fake()->randomElement(ParkingOrientation::toArray()),

--- a/laravel/database/factories/ParkingOffstreetFactory.php
+++ b/laravel/database/factories/ParkingOffstreetFactory.php
@@ -21,8 +21,17 @@ class ParkingOffstreetFactory extends Factory
         return [
             'id' => fake()->unique()->bothify('##??##'),
             'name' => fake()->company,
-            'country_id' => Country::factory(),
-            'province_id' => Province::factory(),
+            'country_id' => function (): mixed {
+                return Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+            },
+            'province_id' => function (): mixed {
+                $countryId = Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+
+                return Province::where('country_id', $countryId)
+                    ->inRandomOrder()
+                    ->value('id')
+                    ?? Province::factory()->create(['country_id' => $countryId])->id;
+            },
             'municipality' => fake()->city,
             'state' => fake()->optional()->state,
             'free_space_short' => fake()->numberBetween(0, 100),

--- a/laravel/database/factories/ParkingRuleFactory.php
+++ b/laravel/database/factories/ParkingRuleFactory.php
@@ -18,7 +18,9 @@ class ParkingRuleFactory extends Factory
     public function definition(): array
     {
         return [
-            'country_id' => Country::factory(),
+            'country_id' => function (): mixed {
+                return Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+            },
             'municipality' => fake()->city,
             'url' => fake()->url,
             'nationwide' => fake()->boolean,

--- a/laravel/database/factories/ProvinceFactory.php
+++ b/laravel/database/factories/ProvinceFactory.php
@@ -18,7 +18,9 @@ class ProvinceFactory extends Factory
     public function definition(): array
     {
         return [
-            'country_id' => Country::factory(),
+            'country_id' => function (): mixed {
+                return Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+            },
             'name' => fake()->name(),
             'geocode' => strtoupper(fake()->bothify('??-##')),
         ];

--- a/laravel/database/factories/UserParkingSpotFactory.php
+++ b/laravel/database/factories/UserParkingSpotFactory.php
@@ -24,11 +24,22 @@ class UserParkingSpotFactory extends Factory
     {
         return [
             'id' => (string) Str::uuid(),
-            'user_id' => User::factory(),
+            'user_id' => function (): mixed {
+                return User::inRandomOrder()->first()->id ?? User::factory()->create()->id;
+            },
             'status' => fake()->randomElement(ParkingStatus::toArray()),
             'ip_address' => fake()->ipv4(),
-            'country_id' => Country::factory(),
-            'province_id' => Province::factory(),
+            'country_id' => function (): mixed {
+                return Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+            },
+            'province_id' => function (): mixed {
+                $countryId = Country::query()->inRandomOrder()->value('id') ?? Country::factory()->create()->id;
+
+                return Province::where('country_id', $countryId)
+                    ->inRandomOrder()
+                    ->value('id')
+                    ?? Province::factory()->create(['country_id' => $countryId])->id;
+            },
             'municipality' => fake()->city,
             'city' => fake()->city,
             'suburb' => fake()->optional()->citySuffix,


### PR DESCRIPTION
Otherwise the seeders will throw error on unique issues.

```txt
SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry 'NC' for key 'countries.countries_code_unique' (Connection: mysql, SQL: insert into countries (name, code, updated_at, created_at) values (Liechtenstein, NC, 2025-02-12 19:22:48, 2025-02-12 19:22:48))
```